### PR TITLE
Add ability to tag tiers within a Compound.

### DIFF
--- a/devtools/travis-ci/post_binstar.sh
+++ b/devtools/travis-ci/post_binstar.sh
@@ -13,6 +13,7 @@ fi
 if [[ "2.7 3.4" =~ "$python" ]]; then
     anaconda -t "$BINSTAR_TOKEN"  upload --force --user iModels --package mbuild-dev $HOME/miniconda/conda-bld/linux-64/mbuild-*
     conda convert $HOME/miniconda/conda-bld/linux-64/mbuild-* -p all
+    pwd
     ls
     anaconda -t "$BINSTAR_TOKEN"  upload --force --user iModels --package mbuild-dev linux-32/mbuild-*
     anaconda -t "$BINSTAR_TOKEN"  upload --force --user iModels --package mbuild-dev win-32/mbuild-*

--- a/mbuild/atom.py
+++ b/mbuild/atom.py
@@ -87,7 +87,8 @@ class Atom(Part):
         return -self.pos
 
     def __repr__(self):
-        return "Atom{0}({1}, {2})".format(id(self), self.name, self.pos)
+        return '<{:s}, pos=[{:.3f}, {:.3f}, {:.3f}]; ID: {}>'.format(
+            self.name, self.pos[0], self.pos[1], self.pos[2], id(self))
 
     def _clone(self, clone_of=None, root_container=None):
         if clone_of is None:

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -39,7 +39,7 @@ def load(filename, relative_to_module=None, frame=-1, compound=None,
         compound = Compound()
 
     traj = md.load(filename, **kwargs)
-    compound.from_trajectory(traj, frame=frame, coords_only=coords_only)
+    compound._from_trajectory(traj, frame=frame, coords_only=coords_only)
     return compound
 
 
@@ -407,19 +407,16 @@ class Compound(Part):
 
     def tag_tier(self, tier_name, compounds=None):
         """Tag all instances of parts in `compounds` with a tier. """
-        n_parts_in_tier = 0
         parts_in_tier = list()
         if compounds is None:  # all-atom
             for atom in self.atoms:
                 atom.tier = tier_name
-                n_parts_in_tier += 1
                 parts_in_tier.append(atom)
         else:
             # Also loop over self since we might want to be tagging that.
             for part in itertools.chain([self], self._yield_parts()):
                 if isinstance(part, tuple(compounds)):
                     part.tier = tier_name
-                    n_parts_in_tier += 1
                     parts_in_tier.append(part)
         self.tiers[tier_name] = parts_in_tier
 
@@ -451,31 +448,30 @@ class Compound(Part):
         except KeyError:  # TODO: better reporting
             saver = None
 
-        if (not saver or extension == '.mol2') and forcefield:
+        if forcefield and (not saver or extension == '.mol2'):
             ff_formats = ', '.join(set(savers.keys()) - set(['.mol2']))
             raise ValueError('The only supported formats with forcefield'
                              'information are: {0}'.format(ff_formats))
 
+        traj = self._to_trajectory(show_ports=show_ports, **kwargs)
         if saver:  # mBuild/InterMol supported saver.
-            traj = self.to_trajectory(show_ports=show_ports, **kwargs)
             return saver(filename, traj)
         else:  # MDTraj supported saver.
-            traj = self.to_trajectory(show_ports=show_ports, **kwargs)
             return traj.save(filename, **kwargs)
 
     def save_mol2(self, filename, traj, **kwargs):
         """ """
         write_mol2(filename, traj)
 
-    def save_hoomdxml(self, filename, traj, force_overwrite=True, **kwargs):
+    def save_hoomdxml(self, filename, traj, force_overwrite=False, **kwargs):
         """ """
         raise NotImplementedError('Interface to InterMol missing')
 
-    def save_gromacs(self, filename, traj, force_overwrite=True, **kwargs):
+    def save_gromacs(self, filename, traj, force_overwrite=False, **kwargs):
         """ """
         raise NotImplementedError('Interface to InterMol missing')
 
-    def save_lammpsdata(self, filename, traj, force_overwrite=True, **kwargs):
+    def save_lammpsdata(self, filename, traj, force_overwrite=False, **kwargs):
         """ """
         raise NotImplementedError('Interface to InterMol missing')
 
@@ -585,7 +581,7 @@ class Compound(Part):
 
     # Interface to Trajectory for reading/writing .pdb and .mol2 files.
     # -----------------------------------------------------------------
-    def from_trajectory(self, traj, frame=-1, coords_only=False):
+    def _from_trajectory(self, traj, frame=-1, coords_only=False):
         """Extract atoms and bonds from a md.Trajectory.
 
         Will create sub-compounds for every chain if there is more than one
@@ -629,7 +625,7 @@ class Compound(Part):
         else:
             self.periodicity = np.array([0., 0., 0.])
 
-    def to_trajectory(self, show_ports=False, chain_types=None, residue_types=None):
+    def _to_trajectory(self, show_ports=False, chain_types=None, residue_types=None):
         """Convert to an md.Trajectory and flatten the compound.
 
         Parameters

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -776,6 +776,7 @@ class Compound(Part):
         from intermol.atom import Atom as InterMolAtom
         from intermol.molecule import Molecule
         from intermol.system import System
+        import simtk.unit as u
 
         if isinstance(molecule_types, list):
             molecule_types = tuple(molecule_types)
@@ -804,7 +805,7 @@ class Compound(Part):
             # Add the actual intermol atoms.
             intermol_atom = InterMolAtom(atom_index + 1, name=atom.name,
                                          residue_index=1, residue_name='RES')
-            intermol_atom.position = atom.pos
+            intermol_atom.position = atom.pos * u.nanometer
             last_molecule.add_atom(intermol_atom)
         return intermol_system
 

--- a/mbuild/part.py
+++ b/mbuild/part.py
@@ -8,14 +8,35 @@ class Part(object):
         compound is the root of the containment hierarchy.
     referrers : set
         Other compounds that reference this part with labels.
-
+    tier : str
+        Name of the user defined tier that this part belongs too.
+    com : np.ndarray, shape=(3,)
+        The center of mass of this part.
     """
-
     def __init__(self):
         super(Part, self).__init__()
         self.parent = None
         # The set of other compounds that reference this compound with labels.
         self.referrers = set()
+
+        self._tier = None
+        self._com = None
+
+    @property
+    def tier(self):
+        return self._tier
+
+    @tier.setter
+    def tier(self, tier_name):
+        self._tier = tier_name
+
+    @property
+    def com(self):
+        return self._com
+
+    @com.setter
+    def com(self, center_of_mass):
+        self._com = center_of_mass
 
     def ancestors(self):
         """Generate all ancestors of the Compound recursively. """

--- a/mbuild/part.py
+++ b/mbuild/part.py
@@ -19,16 +19,7 @@ class Part(object):
         # The set of other compounds that reference this compound with labels.
         self.referrers = set()
 
-        self._tier = None
         self._com = None
-
-    @property
-    def tier(self):
-        return self._tier
-
-    @tier.setter
-    def tier(self, tier_name):
-        self._tier = tier_name
 
     @property
     def com(self):
@@ -44,6 +35,27 @@ class Part(object):
         if self.parent is not None:
             for ancestor in self.parent.ancestors():
                 yield ancestor
+
+    @property
+    def root_compound(self):
+        """Return the root of the compound hierarchy. """
+        for root_of_hierarchy in self.ancestors():
+            pass
+        return root_of_hierarchy
+
+    @property
+    def tier_names(self):
+        """Return the names of the tiers that this compound is tagged with. """
+        root = self.root_compound
+        if root.tiers is None:
+            raise ValueError('No tiers have been tagged in the root of this'
+                             ' hierarchy, {}.'.format(root))
+
+        all_names = list()
+        for tier_name, parts in root.tiers.items():
+            if self in parts:
+                all_names.append(tier_name)
+        return all_names
 
     def _clone(self, clone_of=None, root_container=None):
         raise NotImplementedError

--- a/mbuild/recipes/polymer.py
+++ b/mbuild/recipes/polymer.py
@@ -29,9 +29,8 @@ class Polymer(Compound):
             assert_port_exists(label, proto)
 
         last_part = None
-        for _ in range(0, n):
+        for _ in range(n):
             this_part = clone(proto)
-            self.add(this_part, 'monomer[$]')
             if last_part is None:
                 first_part = this_part
             else:
@@ -40,6 +39,7 @@ class Polymer(Compound):
                 equivalence_transform(this_part, this_part.labels[port_labels[1]],
                                       last_part.labels[port_labels[0]])
             last_part = this_part
+            self.add(this_part, 'monomer[$]')
 
         # Hoist the last part's top port to be the top port of the polymer.
         self.add(last_part.labels[port_labels[0]], port_labels[0], containment=False)

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -1,10 +1,15 @@
 import json
 import os
+
 import numpy as np
 import pytest
+
 import mbuild as mb
 from mbuild.utils.io import get_fn
 from mbuild.tests.base_test import BaseTest
+from mbuild.lib.moieties import CH3
+from mbuild.examples import Ethane
+
 
 class TestCompound(BaseTest):
 
@@ -165,3 +170,16 @@ class TestCompound(BaseTest):
         output = json.loads(ethane._to_json(show_ports=True))
         assert len(output['atoms']) == 8+16
         assert len(output['bonds']) == 7
+
+    def test_tag_tiers(self, ethane):
+        ethane.tag_tier('3-to-1', [Ethane])
+        assert len(ethane.tiers['3-to-1']) == 1
+        assert ethane == ethane.tiers['3-to-1'][0]
+
+        ethane.tag_tier('ua', [CH3])
+        assert len(ethane.tiers['ua']) == 2
+        assert all(isinstance(part, CH3) for part in ethane.tiers['ua'])
+
+        ethane.tag_tier('aa')
+        assert len(ethane.tiers['aa']) == 8
+        assert all(isinstance(part, mb.Atom) for part in ethane.tiers['aa'])

--- a/mbuild/tests/test_compound.py
+++ b/mbuild/tests/test_compound.py
@@ -133,13 +133,13 @@ class TestCompound(BaseTest):
         ethane.visualize(show_ports=True)
 
     def test_to_trajectory(self, ethane, ch3):
-        traj = ethane.to_trajectory()
+        traj = ethane._to_trajectory()
         assert traj.n_atoms == 8
         assert traj.top.n_bonds == 7
         assert traj.n_chains == 1
         assert traj.n_residues == 1
 
-        traj = ethane.to_trajectory(residue_types=ch3)
+        traj = ethane._to_trajectory(residue_types=ch3)
         assert traj.n_atoms == 8
         assert traj.top.n_bonds == 7
         assert traj.n_chains == 1
@@ -147,7 +147,7 @@ class TestCompound(BaseTest):
         assert 'CH3' in [res.name for res in traj.top.residues]
         assert all(res.n_atoms == 4 for res in traj.top.residues)
 
-        traj = ethane.to_trajectory(chain_types=ch3)
+        traj = ethane._to_trajectory(chain_types=ch3)
         assert traj.n_atoms == 8
         assert traj.top.n_bonds == 7
         assert traj.n_chains == 2
@@ -156,7 +156,7 @@ class TestCompound(BaseTest):
         assert all(chain.n_residues == 1 for chain in traj.top.chains)
 
         methyl = next(iter(ethane.parts))
-        traj = methyl.to_trajectory()
+        traj = methyl._to_trajectory()
         assert traj.n_atoms == 4
         assert traj.top.n_bonds == 3
         assert traj.n_chains == 1


### PR DESCRIPTION
An immediate question that crops up is "what about `Part`s that belong to multiple tiers"? For example, an oxygen atom may be part of the all-atom and united-atom tier.

Do we allow the `tier` attribute of `Part`s to be a list?