### PR TITLE
Minor adjustments to LAMMPS and HOOMD writers

### DIFF
--- a/mbuild/formats/hoomdxml.py
+++ b/mbuild/formats/hoomdxml.py
@@ -95,9 +95,8 @@ def write_hoomdxml(structure, filename, forcefield, box, ref_distance=1.0,
     xyz = np.array([[atom.xx, atom.xy, atom.xz] for atom in structure.atoms])
 
     # Center box at origin and remap coordinates into box
-    box.lengths *= 10.0
-    box.maxs *= 10.0
-    box.mins *= 10.0
+    box.maxs *= 10.
+    box.mins *= 10.
     box_init = deepcopy(box)
     box.mins = np.array([-d/2 for d in box_init.lengths])
     box.maxs = np.array([d/2 for d in box_init.lengths])
@@ -145,7 +144,8 @@ def write_hoomdxml(structure, filename, forcefield, box, ref_distance=1.0,
         xml_file.write('</charge>\n')
 
         if forcefield:
-            pair_coeffs = set([(atom.type,atom.epsilon,atom.sigma) for atom in structure.atoms])
+            pair_coeffs = list(set((atom.type,atom.epsilon,atom.sigma) for atom in structure.atoms))
+            pair_coeffs.sort(key=lambda pair_type: pair_type[0])
             xml_file.write('<pair_coeffs>\n')
             for param_set in pair_coeffs:
                 xml_file.write('{}\t{:.4f}\t{:.4f}\n'.format(param_set[0],param_set[1]/ref_energy,param_set[2]/ref_distance))
@@ -156,13 +156,13 @@ def write_hoomdxml(structure, filename, forcefield, box, ref_distance=1.0,
             if len(structure.bond_types) == 0:
                 bond_types = np.zeros(len(bonds),dtype=int)
             else:
-                all_bond_types = dict(enumerate(set([(round(bond.type.k,3),
-                                                      round(bond.type.req,3)) for bond in structure.bonds])))
-                all_bond_types = {y:x for x,y in all_bond_types.items()}
-                bond_types = [all_bond_types[(round(bond.type.k,3),
-                                              round(bond.type.req,3))] for bond in structure.bonds]
+                unique_bond_types = dict(enumerate(set([(round(bond.type.k,3),
+                                                         round(bond.type.req,3)) for bond in structure.bonds])))
+                unique_bond_types = {y:x for x,y in unique_bond_types.items()}
+                bond_types = [unique_bond_types[(round(bond.type.k,3),
+                                                 round(bond.type.req,3))] for bond in structure.bonds]
                 xml_file.write('<bond_coeffs>\n')
-                for params,idx in all_bond_types.items():
+                for params,idx in unique_bond_types.items():
                     xml_file.write('{}\t{}\t{}\n'.format(idx,((params[0]*2.)/ref_energy)*(ref_distance**2.),params[1]/ref_distance))
                 xml_file.write('</bond_coeffs>\n')
             xml_file.write('<bond>\n')
@@ -174,13 +174,13 @@ def write_hoomdxml(structure, filename, forcefield, box, ref_distance=1.0,
                    angle.atom2.idx, 
                    angle.atom3.idx] for angle in structure.angles]
         if angles:
-            all_angle_types = dict(enumerate(set([(round(angle.type.k,3), 
-                                                   round(angle.type.theteq,3)) for angle in structure.angles])))
-            all_angle_types = {y:x for x,y in all_angle_types.items()}
-            angle_types = [all_angle_types[(round(angle.type.k,3), 
-                                            round(angle.type.theteq,3))] for angle in structure.angles]
+            unique_angle_types = dict(enumerate(set([(round(angle.type.k,3), 
+                                                      round(angle.type.theteq,3)) for angle in structure.angles])))
+            unique_angle_types = {y:x for x,y in unique_angle_types.items()}
+            angle_types = [unique_angle_types[(round(angle.type.k,3), 
+                                               round(angle.type.theteq,3))] for angle in structure.angles]
             xml_file.write('<angle_coeffs>\n')
-            for params,idx in all_angle_types.items():
+            for params,idx in unique_angle_types.items():
                 xml_file.write('{}\t{}\t{:.5f}\n'.format(idx,(params[0]*2.)/ref_energy,radians(params[1])))
             xml_file.write('</angle_coeffs>\n')
             xml_file.write('<angle>\n')
@@ -193,25 +193,25 @@ def write_hoomdxml(structure, filename, forcefield, box, ref_distance=1.0,
                       dihedral.atom3.idx,
                       dihedral.atom4.idx] for dihedral in structure.rb_torsions]
         if dihedrals:
-            all_dihedral_types = dict(enumerate(set([(round(dihedral.type.c0,3),
-                                                      round(dihedral.type.c1,3),
-                                                      round(dihedral.type.c2,3),
-                                                      round(dihedral.type.c3,3),
-                                                      round(dihedral.type.c4,3),
-                                                      round(dihedral.type.c5,3),
-                                                      round(dihedral.type.scee,1),
-                                                      round(dihedral.type.scnb,1)) for dihedral in structure.rb_torsions])))
-            all_dihedral_types = {y:x for x,y in all_dihedral_types.items()}
-            dihedral_types = [all_dihedral_types[(round(dihedral.type.c0,3),
-                                                  round(dihedral.type.c1,3),
-                                                  round(dihedral.type.c2,3),
-                                                  round(dihedral.type.c3,3),
-                                                  round(dihedral.type.c4,3),
-                                                  round(dihedral.type.c5,3),
-                                                  round(dihedral.type.scee,1),
-                                                  round(dihedral.type.scnb,1))] for dihedral in structure.rb_torsions]
+            unique_dihedral_types = dict(enumerate(set([(round(dihedral.type.c0,3),
+                                                         round(dihedral.type.c1,3),
+                                                         round(dihedral.type.c2,3),
+                                                         round(dihedral.type.c3,3),
+                                                         round(dihedral.type.c4,3),
+                                                         round(dihedral.type.c5,3),
+                                                         round(dihedral.type.scee,1),
+                                                         round(dihedral.type.scnb,1)) for dihedral in structure.rb_torsions])))
+            unique_dihedral_types = {y:x for x,y in unique_dihedral_types.items()}
+            dihedral_types = [unique_dihedral_types[(round(dihedral.type.c0,3),
+                                                     round(dihedral.type.c1,3),
+                                                     round(dihedral.type.c2,3),
+                                                     round(dihedral.type.c3,3),
+                                                     round(dihedral.type.c4,3),
+                                                     round(dihedral.type.c5,3),
+                                                     round(dihedral.type.scee,1),
+                                                     round(dihedral.type.scnb,1))] for dihedral in structure.rb_torsions]
             xml_file.write('<dihedral_coeffs>\n')
-            for params,idx in all_dihedral_types.items():
+            for params,idx in unique_dihedral_types.items():
                 opls_coeffs = RB_to_OPLS(params[0],
                                          params[1],
                                          params[2],

--- a/mbuild/formats/lammpsdata.py
+++ b/mbuild/formats/lammpsdata.py
@@ -4,8 +4,7 @@ __all__ = ['write_lammpsdata']
 
 
 import numpy as np
-from mbuild.formats.hoomdxml import RB_to_OPLS
-
+from .hoomdxml import RB_to_OPLS
 
 def write_lammpsdata(structure, filename, forcefield, box):
     """Output a LAMMPS data file.
@@ -24,27 +23,17 @@ def write_lammpsdata(structure, filename, forcefield, box):
         Box information to save to data file
     """
 
-    masses = [atom.mass for atom in structure.atoms]
+    # Convert box units from nm to angstroms
+    box.maxs *= 10.
+    box.mins *= 10.
 
     if forcefield:
-        types_str = [atom.type for atom in structure.atoms]
-        types_str_num = [int(atom.split('_')[1]) for atom in types_str]
-        header = types_str[0].split('_')[0]
-        all_types_num = list(set(types_str_num))
-        all_types_num.sort()
-        all_types_num = np.array([[num+1,atom_type] for num,atom_type in enumerate(all_types_num)])
-        all_types = np.array([[num,header+'_'+str(atom_type)] for num,atom_type in all_types_num])
-        type_dict_num = {pair[1]:pair[0] for pair in all_types_num}
+        types = [atom.type for atom in structure.atoms]
+    else:
+        types = [atom.name for atom in structure.atoms]
 
-        mass_dict = dict([(type_dict_num[atom_type],mass) for atom_type,mass in zip(types_str_num,masses)])
-        types = [type_dict_num[atom_type] for atom_type in types_str_num]
-    else:   
-        types_str = [atom.name for atom in structure.atoms]
-        all_types = list(set(types_str))
-        all_types = np.array([[num+1,atom_type] for num,atom_type in enumerate(all_types)])
-        type_dict = {pair[1]:int(pair[0]) for pair in all_types}
-        mass_dict = dict([(type_dict[atom_type],mass) for atom_type,mass in zip(types_str,masses)])
-        types = [type_dict[atom_type] for atom_type in types_str]
+    unique_types = list(set(types))
+    unique_types.sort()
 
     xyz = np.array([[atom.xx,atom.xy,atom.xz] for atom in structure.atoms])
     charges = [atom.charge for atom in structure.atoms]
@@ -62,37 +51,37 @@ def write_lammpsdata(structure, filename, forcefield, box):
         if len(structure.bond_types) == 0:
             bond_types = np.ones(len(bonds),dtype=int)
         else:
-            all_bond_types = dict(enumerate(set([(round(bond.type.k,3),
-                                                  round(bond.type.req,3)) for bond in structure.bonds])))
-            all_bond_types = {y:x+1 for x,y in all_bond_types.items()}
-            bond_types = [all_bond_types[(round(bond.type.k,3),
-                                          round(bond.type.req,3))] for bond in structure.bonds]
+            unique_bond_types = dict(enumerate(set([(round(bond.type.k,3),
+                                                     round(bond.type.req,3)) for bond in structure.bonds])))
+            unique_bond_types = {y:x+1 for x,y in unique_bond_types.items()}
+            bond_types = [unique_bond_types[(round(bond.type.k,3),
+                                             round(bond.type.req,3))] for bond in structure.bonds]
 
     if angles:
-        all_angle_types = dict(enumerate(set([(round(angle.type.k,3),
-                                               round(angle.type.theteq,3)) for angle in structure.angles])))
-        all_angle_types = {y:x+1 for x,y in all_angle_types.items()}
-        angle_types = [all_angle_types[(round(angle.type.k,3),
-                                        round(angle.type.theteq,3))] for angle in structure.angles]
+        unique_angle_types = dict(enumerate(set([(round(angle.type.k,3),
+                                                  round(angle.type.theteq,3)) for angle in structure.angles])))
+        unique_angle_types = {y:x+1 for x,y in unique_angle_types.items()}
+        angle_types = [unique_angle_types[(round(angle.type.k,3),
+                                           round(angle.type.theteq,3))] for angle in structure.angles]
 
     if dihedrals:
-        all_dihedral_types = dict(enumerate(set([(round(dihedral.type.c0,3),
-                                                  round(dihedral.type.c1,3),
-                                                  round(dihedral.type.c2,3),
-                                                  round(dihedral.type.c3,3),
-                                                  round(dihedral.type.c4,3),
-                                                  round(dihedral.type.c5,3),
-                                                  round(dihedral.type.scee,1),
-                                                  round(dihedral.type.scnb,1)) for dihedral in structure.rb_torsions])))
-        all_dihedral_types = {y:x+1 for x,y in all_dihedral_types.items()}
-        dihedral_types = [all_dihedral_types[(round(dihedral.type.c0,3),
-                                              round(dihedral.type.c1,3),
-                                              round(dihedral.type.c2,3),
-                                              round(dihedral.type.c3,3),
-                                              round(dihedral.type.c4,3),
-                                              round(dihedral.type.c5,3),
-                                              round(dihedral.type.scee,1),
-                                              round(dihedral.type.scnb,1))] for dihedral in structure.rb_torsions]
+        unique_dihedral_types = dict(enumerate(set([(round(dihedral.type.c0,3),
+                                                     round(dihedral.type.c1,3),
+                                                     round(dihedral.type.c2,3),
+                                                     round(dihedral.type.c3,3),
+                                                     round(dihedral.type.c4,3),
+                                                     round(dihedral.type.c5,3),
+                                                     round(dihedral.type.scee,1),
+                                                     round(dihedral.type.scnb,1)) for dihedral in structure.rb_torsions])))
+        unique_dihedral_types = {y:x+1 for x,y in unique_dihedral_types.items()}
+        dihedral_types = [unique_dihedral_types[(round(dihedral.type.c0,3),
+                                                 round(dihedral.type.c1,3),
+                                                 round(dihedral.type.c2,3),
+                                                 round(dihedral.type.c3,3),
+                                                 round(dihedral.type.c4,3),
+                                                 round(dihedral.type.c5,3),
+                                                 round(dihedral.type.scee,1),
+                                                 round(dihedral.type.scnb,1))] for dihedral in structure.rb_torsions]
 
     with open(filename, 'w') as data:
         data.write(filename+' - created by mBuild\n\n')
@@ -112,37 +101,39 @@ def write_lammpsdata(structure, filename, forcefield, box):
         data.write('\n')
         # Box data
         for i,dim in enumerate(['x','y','z']):
-            data.write('{0:.6f} {1:.6f} {2}lo {2}hi\n'.format(box.mins[i]*10.,box.maxs[i]*10.,dim))
+            data.write('{0:.6f} {1:.6f} {2}lo {2}hi\n'.format(box.mins[i],box.maxs[i],dim))
 
         # Mass data
-        type_dict_r = {int(pair[0]):pair[1] for pair in all_types}
+        masses = [atom.mass for atom in structure.atoms]
+        mass_dict = dict([(unique_types.index(atom_type)+1,mass) for atom_type,mass in zip(types,masses)])
+
         data.write('\nMasses\n\n')
         for atom_type,mass in mass_dict.items():
-            data.write('{:d}\t{:.6f}\t# {}\n'.format(atom_type,mass,type_dict_r[atom_type]))
+            data.write('{:d}\t{:.6f}\t# {}\n'.format(atom_type,mass,unique_types[atom_type-1]))
 
         if forcefield:
             # Pair coefficients
             epsilons = [atom.epsilon for atom in structure.atoms]
             sigmas = [atom.sigma for atom in structure.atoms]
-            epsilon_dict = dict([(type_dict_num[atom_type],epsilon) for atom_type,epsilon in zip(types_str_num,epsilons)])
-            sigma_dict = dict([(type_dict_num[atom_type],sigma) for atom_type,sigma in zip(types_str_num,sigmas)])
+            epsilon_dict = dict([(unique_types.index(atom_type)+1,epsilon) for atom_type,epsilon in zip(types,epsilons)])
+            sigma_dict = dict([(unique_types.index(atom_type)+1,sigma) for atom_type,sigma in zip(types,sigmas)])
             data.write('\nPair Coeffs # lj\n\n')
             for idx,epsilon in epsilon_dict.items():
                 data.write('{}\t{:.5f}\t{:.5f}\n'.format(idx,epsilon,sigma_dict[idx]))
 
             # Bond coefficients
             data.write('\nBond Coeffs # harmonic\n\n')
-            for params,idx in all_bond_types.items():
+            for params,idx in unique_bond_types.items():
                 data.write('{}\t{}\t{}\n'.format(idx,*params))
 
             # Angle coefficients
             data.write('\nAngle Coeffs # harmonic\n\n')
-            for params,idx in all_angle_types.items():
+            for params,idx in unique_angle_types.items():
                 data.write('{}\t{}\t{:.5f}\n'.format(idx,*params))
 
             # Dihedral coefficients
             data.write('\nDihedral Coeffs # opls\n\n')
-            for params,idx in all_dihedral_types.items():
+            for params,idx in unique_dihedral_types.items():
                 opls_coeffs = RB_to_OPLS(params[0],
                                          params[1],
                                          params[2],
@@ -154,7 +145,7 @@ def write_lammpsdata(structure, filename, forcefield, box):
         # Atom data
         data.write('\nAtoms\n\n')
         for i,coords in enumerate(xyz):
-            data.write('{:d}\t{:d}\t{:d}\t{:.6f}\t{:.6f}\t{:.6f}\t{:.6f}\n'.format(i+1,0,types[i],charges[i],*coords))
+            data.write('{:d}\t{:d}\t{:d}\t{:.6f}\t{:.6f}\t{:.6f}\t{:.6f}\n'.format(i+1,0,unique_types.index(types[i])+1,charges[i],*coords))
 
         # Bond data
         if bonds:

--- a/mbuild/formats/lammpsdata.py
+++ b/mbuild/formats/lammpsdata.py
@@ -35,7 +35,7 @@ def write_lammpsdata(structure, filename, forcefield, box):
         types = [atom.name for atom in structure.atoms]
 
     unique_types = list(set(types))
-    unique_types.sort(key=_natural_keys)
+    unique_types.sort(key=_natural_sort)
 
     xyz = np.array([[atom.xx,atom.xy,atom.xz] for atom in structure.atoms])
     charges = [atom.charge for atom in structure.atoms]


### PR DESCRIPTION
Cleaned up some code in the LAMMPS and HOOMD writers to make more readable.  The LAMMPS writer should now support arbitrary atom names (previously names were required to be in a "forcefield_#" format).
