### PR TITLE
Converted 'n' in polymer class to a required argument

### DIFF
--- a/mbuild/recipes/polymer.py
+++ b/mbuild/recipes/polymer.py
@@ -26,7 +26,7 @@ class Polymer(Compound):
         The names of the two ports to use to connect copies of proto.
 
     """
-    def __init__(self, monomers, sequence='A', n=2, port_labels=('up', 'down')):
+    def __init__(self, monomers, n, sequence='A', port_labels=('up', 'down')):
         if n < 1:
             raise ValueError('n must be 1 or more')
         super(Polymer, self).__init__()


### PR DESCRIPTION
Ran into an issue in a script where the Polymer class was being erroneously instantiated, and the bug took a while to find because no error was being generated.  This isn't a big issue either way, but I think it makes more sense to require the user to provide a length for their polymer.