### PR TITLE
Minor fix to hoomdxml writer

### DIFF
--- a/mbuild/formats/hoomdxml.py
+++ b/mbuild/formats/hoomdxml.py
@@ -227,10 +227,10 @@ def write_hoomdxml(structure, filename, forcefield, box, ref_distance=1.0,
                                                              *dihedral))
             xml_file.write('</dihedral>\n')
 
-        if rigid_bodies:
+        if rigid_bodies is not None:
             xml_file.write('<body>\n')
             for body in rigid_bodies:
-                xml_file.write('{}\n'.format(body))
+                xml_file.write('{}\n'.format(int(body)))
             xml_file.write('</body>\n')
         
         xml_file.write('</configuration>\n')

--- a/mbuild/tests/test_hoomdxml.py
+++ b/mbuild/tests/test_hoomdxml.py
@@ -19,3 +19,12 @@ class TestHoomdXML(BaseTest):
     def test_save_box(self, ethane):
         box = mb.Box(lengths=np.array([2.0, 2.0, 2.0]))
         ethane.save(filename='ethane-box.hoomdxml', forcefield='opls', box=box)
+
+    @pytest.mark.skipif(not has_foyer, reason="Foyer is not installed")
+    def test_rigid(self, ethane):
+        box = mb.Box(lengths=np.array([2.0, 2.0, 2.0]))
+        rigid = np.zeros(ethane.n_particles)
+        ethane.save(filename='ethane-box.hoomdxml',
+                    forcefield='opls',
+                    box=box,
+                    rigid_bodies=rigid)


### PR DESCRIPTION
Fixed a minor bug where rigid bodies are written to the hoomdxml file.  Also added a unit test for saving a compound containing rigid bodies.