### PR TITLE
Hoomd GSD writer

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -10,7 +10,7 @@ requirements:
     - python
     - numpy
     - scipy
-    - packmol
+    - packmol 1.0.0 4
     - nglview
     - oset
     - parmed
@@ -25,6 +25,9 @@ test:
     - ipyext
   commands:
     - py.test -v --pyargs mbuild
+    - echo {{SRC_DIR}}
+    - echo {{SRC_DIR/*}}
+    - echo {{SRC_DIR/*/*}}
     - cd {{SRC_DIR}}
     - cd mbuild/examples
     - py.test test_examples.py -v

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -26,8 +26,8 @@ test:
   commands:
     - py.test -v --pyargs mbuild
     - echo {{SRC_DIR}}
-    - echo {{SRC_DIR/*}}
-    - echo {{SRC_DIR/*/*}}
+    - echo {{SRC_DIR}}/*
+    - echo {{SRC_DIR}}/*/*
     - cd {{SRC_DIR}}
     - cd mbuild/examples
     - py.test test_examples.py -v

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -21,7 +21,6 @@ from mbuild.periodic_kdtree import PeriodicCKDTree
 from mbuild.utils.io import run_from_ipython
 from mbuild.formats.hoomdxml import write_hoomdxml
 from mbuild.formats.lammpsdata import write_lammpsdata
-from mbuild.formats.gsdwriter import write_gsd
 
 
 __all__ = ['load', 'clone', 'Compound', 'Particle']
@@ -554,6 +553,7 @@ class Compound(object):
 
     def save_gsd(self, filename, structure, forcefield, box=None, **kwargs):
         """ """
+        from mbuild.formats.gsdwriter import write_gsd
         if forcefield:
             from foyer.forcefield import apply_forcefield
             structure = apply_forcefield(structure, forcefield=forcefield)

--- a/mbuild/compound.py
+++ b/mbuild/compound.py
@@ -21,6 +21,7 @@ from mbuild.periodic_kdtree import PeriodicCKDTree
 from mbuild.utils.io import run_from_ipython
 from mbuild.formats.hoomdxml import write_hoomdxml
 from mbuild.formats.lammpsdata import write_lammpsdata
+from mbuild.formats.gsdwriter import write_gsd
 
 
 __all__ = ['load', 'clone', 'Compound', 'Particle']
@@ -516,6 +517,7 @@ class Compound(object):
         extension = os.path.splitext(filename)[-1]
 
         savers = {'.hoomdxml': self.save_hoomdxml,
+                  '.gsd': self.save_gsd,
                   '.gro': self.save_gromacs,
                   '.top': self.save_gromacs,
                   '.lammps': self.save_lammpsdata,
@@ -549,6 +551,24 @@ class Compound(object):
                     box.mins[dim] -= 0.25
                     box.lengths[dim] += 0.5
         write_hoomdxml(structure, filename, forcefield, box, **kwargs)
+
+    def save_gsd(self, filename, structure, forcefield, box=None, **kwargs):
+        """ """
+        if forcefield:
+            from foyer.forcefield import apply_forcefield
+            structure = apply_forcefield(structure, forcefield=forcefield)
+        if not box:
+            box = self.boundingbox
+            for dim, val in enumerate(self.periodicity):
+                if val:
+                    box.lengths[dim] = val
+                    box.maxs[dim] = val
+                    box.mins[dim] = 0.0
+                if not val:
+                    box.maxs[dim] += 0.25
+                    box.mins[dim] -= 0.25
+                    box.lengths[dim] += 0.5
+        write_gsd(structure, filename, forcefield, box, **kwargs)
 
     def save_gromacs(self, filename, structure, forcefield, force_overwrite=False, **kwargs):
         """ """

--- a/mbuild/formats/ff_to_json.py
+++ b/mbuild/formats/ff_to_json.py
@@ -5,11 +5,12 @@ __all__ = ['write_forcefield']
 
 import json
 import parmed as pmd
+import numpy as np
 from parmed.periodic_table import AtomicNum
 from .hoomdxml import RB_to_OPLS
 from collections import OrderedDict
 
-def write_forcefield(structure, filename):
+def write_forcefield(structure, filename, ref_distance=1.0, ref_energy=1.0):
 
     params = pmd.ParameterSet.from_structure(structure)
 
@@ -26,8 +27,8 @@ def write_forcefield(structure, filename):
         for key in params.atom_types.items():
             temp_dict = OrderedDict()
             temp_dict['element'] = {enum:ename for ename,enum in AtomicNum.items()}[key[1].atomic_number]
-            temp_dict['epsilon'] = round(key[1].epsilon,3)
-            temp_dict['sigma'] = round(key[1].sigma,3)
+            temp_dict['epsilon'] = round(key[1].epsilon,3) / ref_energy
+            temp_dict['sigma'] = round(key[1].sigma,3) / ref_distance
             pair_data[key[0]] = temp_dict
 
         ff_data['pair_coeffs'] = pair_data
@@ -36,8 +37,8 @@ def write_forcefield(structure, filename):
         bond_data = OrderedDict()
         for key in structure.bond_types:
             temp_dict = OrderedDict()
-            temp_dict['k'] = round(key.k,3)
-            temp_dict['req'] = round(key.req,3)
+            temp_dict['k'] = round(key.k,3) * ((ref_distance**2)/ref_energy)
+            temp_dict['req'] = round(key.req,3) / ref_distance
             bond_data[str(key.idx)] = temp_dict
 
         ff_data['bond_coeffs'] = bond_data
@@ -46,8 +47,8 @@ def write_forcefield(structure, filename):
         angle_data = OrderedDict()
         for key in structure.angle_types:
             temp_dict = OrderedDict()
-            temp_dict['k'] = round(key.k,3)
-            temp_dict['theteq'] = round(key.theteq,3)
+            temp_dict['k'] = round(key.k,3) / ref_energy
+            temp_dict['theteq'] = round(key.theteq,3) * (np.pi/180)
             angle_data[str(key.idx)] = temp_dict
 
         ff_data['angle_coeffs'] = angle_data
@@ -70,10 +71,10 @@ def write_forcefield(structure, filename):
         dihedral_data = OrderedDict()
         for idx,key in enumerate(dihedrals_opls):
             temp_dict = OrderedDict()
-            temp_dict['k0'] = round(key[0],3)
-            temp_dict['k1'] = round(key[1],3)
-            temp_dict['k2'] = round(key[2],3)
-            temp_dict['k3'] = round(key[3],3)
+            temp_dict['k0'] = round(key[0],3) / ref_energy
+            temp_dict['k1'] = round(key[1],3) / ref_energy
+            temp_dict['k2'] = round(key[2],3) / ref_energy
+            temp_dict['k3'] = round(key[3],3) / ref_energy
             dihedral_data[str(idx)] = temp_dict
             
         ff_data['dihedral_coeffs'] = dihedral_data

--- a/mbuild/formats/ff_to_json.py
+++ b/mbuild/formats/ff_to_json.py
@@ -1,0 +1,81 @@
+from __future__ import division
+
+__all__ = ['write_forcefield']
+
+
+import json
+import parmed as pmd
+from parmed.periodic_table import AtomicNum
+from .hoomdxml import RB_to_OPLS
+from collections import OrderedDict
+
+def write_forcefield(structure, filename):
+
+    params = pmd.ParameterSet.from_structure(structure)
+
+    ff_data = OrderedDict()
+    ff_data['styles'] = OrderedDict([('pair','lj'),
+                                     ('bond','harmonic'),
+                                     ('angle','harmonic'),
+                                     ('dihedral','opls')])
+
+    with open(filename, 'w') as f:
+
+        # Pair
+        pair_data = OrderedDict()
+        for key in params.atom_types.items():
+            temp_dict = OrderedDict()
+            temp_dict['element'] = {enum:ename for ename,enum in AtomicNum.items()}[key[1].atomic_number]
+            temp_dict['epsilon'] = round(key[1].epsilon,3)
+            temp_dict['sigma'] = round(key[1].sigma,3)
+            pair_data[key[0]] = temp_dict
+
+        ff_data['pair_coeffs'] = pair_data
+
+        # Bonds
+        bond_data = OrderedDict()
+        for key in structure.bond_types:
+            temp_dict = OrderedDict()
+            temp_dict['k'] = round(key.k,3)
+            temp_dict['req'] = round(key.req,3)
+            bond_data[str(key.idx)] = temp_dict
+
+        ff_data['bond_coeffs'] = bond_data
+
+        # Angles
+        angle_data = OrderedDict()
+        for key in structure.angle_types:
+            temp_dict = OrderedDict()
+            temp_dict['k'] = round(key.k,3)
+            temp_dict['theteq'] = round(key.theteq,3)
+            angle_data[str(key.idx)] = temp_dict
+
+        ff_data['angle_coeffs'] = angle_data
+
+        # Dihedrals
+        dihedrals = structure.rb_torsion_types
+        for i,dihedral in enumerate(dihedrals):
+            for j in range(i+1, len(dihedrals)):
+                dihedral2 = dihedrals[j]
+                if dihedral == dihedral2:
+                    dihedrals[j] = dihedral
+        dihedrals = list(set(dihedrals))
+        dihedrals_opls = [RB_to_OPLS(dihedral.c0,
+                                     dihedral.c1,
+                                     dihedral.c2,
+                                     dihedral.c3,
+                                     dihedral.c4,
+                                     dihedral.c5) for dihedral in dihedrals]
+
+        dihedral_data = OrderedDict()
+        for idx,key in enumerate(dihedrals_opls):
+            temp_dict = OrderedDict()
+            temp_dict['k0'] = round(key[0],3)
+            temp_dict['k1'] = round(key[1],3)
+            temp_dict['k2'] = round(key[2],3)
+            temp_dict['k3'] = round(key[3],3)
+            dihedral_data[str(idx)] = temp_dict
+            
+        ff_data['dihedral_coeffs'] = dihedral_data
+
+        json.dump(ff_data,f,indent=4)

--- a/mbuild/formats/ff_to_json.py
+++ b/mbuild/formats/ff_to_json.py
@@ -3,6 +3,7 @@ from __future__ import division
 __all__ = ['write_forcefield']
 
 
+import re
 import json
 import parmed as pmd
 import numpy as np
@@ -11,72 +12,95 @@ from .hoomdxml import RB_to_OPLS
 from collections import OrderedDict
 
 def write_forcefield(structure, filename, ref_distance=1.0, ref_energy=1.0):
+    """Output force field information in JSON format.
+
+    Parameters
+    ----------
+    structure : parmed.GromacsTopologyFile
+        Parmed structure object
+    filename : str
+        Path of the output file.
+    ref_distance : float, default=1.0
+        Reference distance for conversion to reduced units
+    ref_energy : float, default=1.0
+        Reference energy for conversion to reduced units
+    """
 
     params = pmd.ParameterSet.from_structure(structure)
-
     ff_data = OrderedDict()
-    ff_data['styles'] = OrderedDict([('pair','lj'),
-                                     ('bond','harmonic'),
-                                     ('angle','harmonic'),
-                                     ('dihedral','opls')])
+
+    styles = OrderedDict()
 
     with open(filename, 'w') as f:
 
         # Pair
-        pair_data = OrderedDict()
+        charges = np.any([atom.charge for atom in structure.atoms])
+        if charges:
+            styles['pair'] = 'lj/coul'
+        else:
+            styles['pair'] = 'lj'
+
+        pair_data = dict()
         for key in params.atom_types.items():
             temp_dict = OrderedDict()
             temp_dict['element'] = {enum:ename for ename,enum in AtomicNum.items()}[key[1].atomic_number]
             temp_dict['epsilon'] = round(key[1].epsilon,3) / ref_energy
             temp_dict['sigma'] = round(key[1].sigma,3) / ref_distance
             pair_data[key[0]] = temp_dict
-
-        ff_data['pair_coeffs'] = pair_data
+        pair_data = OrderedDict(sorted(pair_data.items(), key=lambda(key,value):int(key.split('_')[1])))
 
         # Bonds
-        bond_data = OrderedDict()
-        for key in structure.bond_types:
-            temp_dict = OrderedDict()
-            temp_dict['k'] = round(key.k,3) * ((ref_distance**2)/ref_energy)
-            temp_dict['req'] = round(key.req,3) / ref_distance
-            bond_data[str(key.idx)] = temp_dict
-
-        ff_data['bond_coeffs'] = bond_data
+        bonds = [bond for bond in structure.bonds]
+        if bonds:
+            styles['bond'] = 'harmonic'
+            bond_data = OrderedDict()
+            for key in structure.bond_types:
+                temp_dict = OrderedDict()
+                temp_dict['k'] = round(key.k*2,3) * ((ref_distance**2)/ref_energy)
+                temp_dict['r0'] = round(key.req,3) / ref_distance
+                bond_data[str(key.idx)] = temp_dict
 
         # Angles
-        angle_data = OrderedDict()
-        for key in structure.angle_types:
-            temp_dict = OrderedDict()
-            temp_dict['k'] = round(key.k,3) / ref_energy
-            temp_dict['theteq'] = round(key.theteq,3) * (np.pi/180)
-            angle_data[str(key.idx)] = temp_dict
-
-        ff_data['angle_coeffs'] = angle_data
+        angles = [angle for angle in structure.angles]
+        if angles:
+            styles['angle'] = 'harmonic'
+            angle_data = OrderedDict()
+            for key in structure.angle_types:
+                temp_dict = OrderedDict()
+                temp_dict['k'] = round(key.k*2,3) / ref_energy
+                temp_dict['t0'] = round(key.theteq,3) * (np.pi/180)
+                angle_data[str(key.idx)] = temp_dict
 
         # Dihedrals
-        dihedrals = structure.rb_torsion_types
-        for i,dihedral in enumerate(dihedrals):
-            for j in range(i+1, len(dihedrals)):
-                dihedral2 = dihedrals[j]
-                if dihedral == dihedral2:
-                    dihedrals[j] = dihedral
-        dihedrals = list(set(dihedrals))
-        dihedrals_opls = [RB_to_OPLS(dihedral.c0,
-                                     dihedral.c1,
-                                     dihedral.c2,
-                                     dihedral.c3,
-                                     dihedral.c4,
-                                     dihedral.c5) for dihedral in dihedrals]
-
-        dihedral_data = OrderedDict()
-        for idx,key in enumerate(dihedrals_opls):
-            temp_dict = OrderedDict()
-            temp_dict['k0'] = round(key[0],3) / ref_energy
-            temp_dict['k1'] = round(key[1],3) / ref_energy
-            temp_dict['k2'] = round(key[2],3) / ref_energy
-            temp_dict['k3'] = round(key[3],3) / ref_energy
-            dihedral_data[str(idx)] = temp_dict
+        dihedrals = [dihedral for dihedral in structure.rb_torsions]
+        if dihedrals:
+            styles['dihedral'] = 'opls'
+            dihedrals = structure.rb_torsion_types
+            for i,dihedral in enumerate(dihedrals):
+                for j in range(i+1, len(dihedrals)):
+                    dihedral2 = dihedrals[j]
+                    if dihedral == dihedral2:
+                        dihedrals[j] = dihedral
+            dihedrals = list(set(dihedrals))
+            dihedrals_opls = [RB_to_OPLS(dihedral.c0,
+                                         dihedral.c1,
+                                         dihedral.c2,
+                                         dihedral.c3,
+                                         dihedral.c4,
+                                         dihedral.c5) for dihedral in dihedrals]
+            dihedral_data = OrderedDict()
+            for idx,key in enumerate(dihedrals_opls):
+                temp_dict = OrderedDict()
+                temp_dict['k1'] = round(key[0],3) / ref_energy
+                temp_dict['k2'] = round(key[1],3) / ref_energy
+                temp_dict['k3'] = round(key[2],3) / ref_energy
+                temp_dict['k4'] = round(key[3],3) / ref_energy
+                dihedral_data[str(idx)] = temp_dict
             
+        ff_data['styles'] = styles
+        ff_data['pair_coeffs'] = pair_data
+        ff_data['bond_coeffs'] = bond_data
+        ff_data['angle_coeffs'] = angle_data
         ff_data['dihedral_coeffs'] = dihedral_data
 
         json.dump(ff_data,f,indent=4)

--- a/mbuild/formats/gsdwriter.py
+++ b/mbuild/formats/gsdwriter.py
@@ -9,6 +9,7 @@ import gsd.hoomd
 from copy import deepcopy
 from math import floor
 from collections import OrderedDict
+from oset import oset as OrderedSet
 from .ff_to_json import write_forcefield
 
 
@@ -92,14 +93,16 @@ def write_gsd(structure, filename, forcefield, box, ref_distance=1.0, ref_mass=1
     if bonds:
         bonds = np.asarray(bonds)
         gsd_file.bonds.N = len(bonds)
-
         if len(structure.bond_types) == 0:
             bond_types = np.zeros(len(bonds),dtype=int)
             gsd_file.bonds.types = ['0']
         else:
-            unique_bond_types = OrderedDict([(btype,btype.idx) for btype in structure.bond_types])
-            bond_types = [unique_bond_types[bond.type] for bond in structure.bonds]
-            gsd_file.bonds.types = [str(btype) for btype in range(len(unique_bond_types))]
+            unique_bond_types = dict(enumerate(OrderedSet([(round(bond.type.k,3),
+                                                            round(bond.type.req,3)) for bond in structure.bonds])))
+            unique_bond_types = OrderedDict([(y,x) for x,y in unique_bond_types.items()])
+            bond_types = [unique_bond_types[(round(bond.type.k,3),
+                                             round(bond.type.req,3))] for bond in structure.bonds]
+            gsd_file.bonds.types = [str(y) for x,y in unique_bond_types.items()]
         gsd_file.bonds.typeid = bond_types
         gsd_file.bonds.group = bonds
 
@@ -109,9 +112,12 @@ def write_gsd(structure, filename, forcefield, box, ref_distance=1.0, ref_mass=1
     if angles:
         angles = np.asarray(angles)
         gsd_file.angles.N = len(angles)
-        unique_angle_types = OrderedDict([(atype,atype.idx) for atype in structure.angle_types])
-        angle_types = [unique_angle_types[angle.type] for angle in structure.angles]
-        gsd_file.angles.types = [str(atype) for atype in range(len(unique_angle_types))]
+        unique_angle_types = dict(enumerate(OrderedSet([(round(angle.type.k,3),
+                                                         round(angle.type.theteq,3)) for angle in structure.angles])))
+        unique_angle_types = OrderedDict([(y,x) for x,y in unique_angle_types.items()])
+        angle_types = [unique_angle_types[(round(angle.type.k,3),
+                                           round(angle.type.theteq,3))] for angle in structure.angles]
+        gsd_file.angles.types = [str(y) for x,y in unique_angle_types.items()]
         gsd_file.angles.typeid = angle_types
         gsd_file.angles.group = angles
 
@@ -122,9 +128,25 @@ def write_gsd(structure, filename, forcefield, box, ref_distance=1.0, ref_mass=1
     if dihedrals:
         dihedrals = np.asarray(dihedrals)
         gsd_file.dihedrals.N = len(dihedrals)
-        unique_dihedral_types = OrderedDict([(dtype,dtype.idx) for dtype in structure.rb_torsion_types])
-        dihedral_types = [unique_dihedral_types[dihedral.type] for dihedral in structure.rb_torsions]
-        gsd_file.dihedrals.types = [str(dtype) for dtype in range(len(unique_dihedral_types))]
+
+        unique_dihedral_types = dict(enumerate(OrderedSet([(round(dihedral.type.c0,3),
+                                                    round(dihedral.type.c1,3),
+                                                    round(dihedral.type.c2,3),
+                                                    round(dihedral.type.c3,3),
+                                                    round(dihedral.type.c4,3),
+                                                    round(dihedral.type.c5,3),
+                                                    round(dihedral.type.scee,1),
+                                                    round(dihedral.type.scnb,1)) for dihedral in structure.rb_torsions])))
+        unique_dihedral_types = OrderedDict([(y,x) for x,y in unique_dihedral_types.items()])
+        dihedral_types = [unique_dihedral_types[(round(dihedral.type.c0,3),
+                                                 round(dihedral.type.c1,3),
+                                                 round(dihedral.type.c2,3),
+                                                 round(dihedral.type.c3,3),
+                                                 round(dihedral.type.c4,3),
+                                                 round(dihedral.type.c5,3),
+                                                 round(dihedral.type.scee,1),
+                                                 round(dihedral.type.scnb,1))] for dihedral in structure.rb_torsions]
+        gsd_file.dihedrals.types = [str(y) for x,y in unique_dihedral_types.items()]
         gsd_file.dihedrals.typeid = dihedral_types
         gsd_file.dihedrals.group = dihedrals
 

--- a/mbuild/formats/gsdwriter.py
+++ b/mbuild/formats/gsdwriter.py
@@ -1,0 +1,162 @@
+from __future__ import division
+
+__all__ = ['write_gsd']
+
+
+from copy import deepcopy
+from math import floor
+import numpy as np
+import gsd.hoomd
+from .hoomdxml import RB_to_OPLS
+from .ff_to_json import write_forcefield
+
+from oset import oset as OrderedSet
+from collections import OrderedDict
+
+
+def write_gsd(structure, filename, forcefield, box, ref_distance=1.0, ref_mass=1.0,
+              write_ff=True):
+    """Output a GSD file (HOOMD default data format).
+    
+    Parameters
+    ----------
+    structure : parmed.GromacsTopologyFile
+        Parmed structure object
+    filename : str
+        Path of the output file.
+    box : mb.Box
+        Box information to save to XML file
+    forcefield : str, default=None
+        Name of the force field to be applied to the compound
+    ref_distance : float, default=1.0
+        Reference distance for conversion to reduced units
+    ref_mass : float, default=1.0
+        Reference mass for conversion to reduced units
+    """
+
+    if write_ff:
+        write_forcefield(structure, 'parameters.json')
+        #out_file_json = open('parameters.json','w')
+    #params = Parameters()
+
+    xyz = np.array([[atom.xx,atom.xy,atom.xz] for atom in structure.atoms])
+
+    # Center box at origin and remap coordinates into box
+    box.lengths *= 10.0
+    box.maxs *= 10.0
+    box.mins *= 10.0
+    box_init = deepcopy(box)
+    box.mins = np.array([-d/2 for d in box_init.lengths])
+    box.maxs = np.array([d/2 for d in box_init.lengths])
+    
+    shift = [box_init.maxs[i] - max for i,max in enumerate(box.maxs)]
+    for i,pos in enumerate(xyz):
+        for j,coord in enumerate(pos):
+            xyz[i,j] -= shift[j]
+            rep = floor((xyz[i,j]-box.mins[j])/box.lengths[j])
+            xyz[i,j] -= (rep * box.lengths[j])
+
+    gsd_file = gsd.hoomd.Snapshot()
+
+    gsd_file.configuration.step = 0
+    gsd_file.configuration.dimensions = 3
+    gsd_file.configuration.box = np.hstack((box.lengths/ref_distance,np.zeros(3)))
+
+    gsd_file.particles.N = len(structure.atoms)
+    gsd_file.particles.position = xyz/ref_distance
+
+    if forcefield:
+        types = [atom.type for atom in structure.atoms]
+    else:
+        types = [atom.name for atom in structure.atoms]
+    ntypes = 0
+    mapping = OrderedDict()
+    for t in types:
+        if t not in mapping:
+            mapping[t] = ntypes
+            ntypes = ntypes+1
+    typeids = np.array([mapping[t] for t in types])
+
+    unique_types = OrderedSet(types)
+    for unique_type in unique_types:
+        ref_atom = structure.atoms[types.index(unique_type)]
+        '''
+        params.add_atom(name=ref_atom.type,
+                        bond_type=ref_atom.name,
+                        atomic_number=ref_atom.atomic_number,
+                        mass=ref_atom.mass,
+                        charge=ref_atom.charge,
+                        ptype='A',
+                        sigma=ref_atom.sigma,
+                        epsilon=ref_atom.epsilon)
+        '''
+
+    gsd_file.particles.types = types
+    gsd_file.particles.typeids = typeids
+    
+    masses = np.array([atom.mass for atom in structure.atoms])
+    masses[masses==0] = 1.0
+    gsd_file.particles.mass = masses/ref_mass
+
+    gsd_file.particles.charge = np.array([atom.charge for atom in structure.atoms])
+
+    bonds = [[bond.atom1.idx, bond.atom2.idx] for bond in structure.bonds]
+    if bonds:
+        bonds = np.asarray(bonds)
+        gsd_file.bonds.N = len(bonds)
+
+        if len(structure.bond_types) == 0:
+            bond_types = np.zeros(len(bonds),dtype=int)
+        else:
+            all_bond_types = OrderedDict(enumerate(set([(round(bond.type.k,3),
+                                                         round(bond.type.req,3)) for bond in structure.bonds])))
+            all_bond_types = OrderedDict([(y,x) for x,y in all_bond_types.items()])
+            bond_types = np.array([all_bond_types[(round(bond.type.k,3),round(bond.type.req,3))] for bond in structure.bonds])
+        gsd_file.bonds.typeid = bond_types
+        gsd_file.bonds.types = [str(t) for t in bond_types]
+        gsd_file.bonds.group = bonds
+
+    angles = [[angle.atom1.idx,
+               angle.atom2.idx, 
+               angle.atom3.idx] for angle in structure.angles]
+    if angles:
+        angles = np.asarray(angles)
+        gsd_file.angles.N = len(angles)
+        all_angle_types = OrderedDict(enumerate(set([(round(angle.type.k,3), 
+                                                      round(angle.type.theteq,3)) for angle in structure.angles])))
+        all_angle_types = OrderedDict([(y,x) for x,y in all_angle_types.items()])
+        angle_types = np.array([all_angle_types[(round(angle.type.k,3),round(angle.type.theteq,3))] for angle in structure.angles])
+        gsd_file.angles.typeid = angle_types
+        gsd_file.angles.types = [str(t) for t in angle_types]
+        gsd_file.angles.group = angles
+
+    dihedrals = [[dihedral.atom1.idx,
+                  dihedral.atom2.idx,
+                  dihedral.atom3.idx,
+                  dihedral.atom4.idx] for dihedral in structure.rb_torsions]
+    if dihedrals:
+        dihedrals = np.asarray(dihedrals)
+        gsd_file.dihedrals.N = len(dihedrals)
+        all_dihedral_types = OrderedDict(enumerate(set([(round(dihedral.type.c0,3),
+                                                         round(dihedral.type.c1,3),
+                                                         round(dihedral.type.c2,3),
+                                                         round(dihedral.type.c3,3),
+                                                         round(dihedral.type.c4,3),
+                                                         round(dihedral.type.c5,3),
+                                                         round(dihedral.type.scee,1),
+                                                         round(dihedral.type.scnb,1)) for dihedral in structure.rb_torsions])))
+        all_dihedral_types = OrderedDict([(y,x) for x,y in all_dihedral_types.items()])
+        dihedral_types = np.array([all_dihedral_types[(round(dihedral.type.c0,3),
+                                                round(dihedral.type.c1,3),
+                                                round(dihedral.type.c2,3),
+                                                round(dihedral.type.c3,3),
+                                                round(dihedral.type.c4,3),
+                                                round(dihedral.type.c5,3),
+                                                round(dihedral.type.scee,1),
+                                                round(dihedral.type.scnb,1))] for dihedral in structure.rb_torsions])
+        gsd_file.dihedrals.typeid = dihedral_types
+        gsd_file.dihedrals.types = [str(t) for t in dihedral_types]
+        gsd_file.dihedrals.group = dihedrals
+
+    gsd.hoomd.create(filename, gsd_file)
+    #params.print_json(out_file_json)

--- a/mbuild/tests/test_gsd.py
+++ b/mbuild/tests/test_gsd.py
@@ -2,18 +2,21 @@ import mbuild as mb
 import numpy as np
 import pytest
 from mbuild.tests.base_test import BaseTest
-from mbuild.utils.io import has_foyer
+from mbuild.utils.io import has_foyer, has_gsd
 
 
 class TestGSD(BaseTest):
 
+    @pytest.mark.skipif(not has_gsd, reason="GSD package not installed")
     def test_save(self, ethane):
         ethane.save(filename='ethane.gsd',write_ff=False)
 
+    @pytest.mark.skipif(not has_gsd, reason="GSD package not installed")
     @pytest.mark.skipif(not has_foyer, reason="Foyer is not installed")
     def test_save_forcefield(self, ethane):
         ethane.save(filename='ethane-opls.gsd',forcefield='opls')
 
+    @pytest.mark.skipif(not has_gsd, reason="GSD package not installed")
     @pytest.mark.skipif(not has_foyer, reason="Foyer is not installed")
     def test_save_box(self, ethane):
         box = mb.Box(lengths=np.array([2.0,2.0,2.0]))

--- a/mbuild/tests/test_gsd.py
+++ b/mbuild/tests/test_gsd.py
@@ -1,0 +1,20 @@
+import mbuild as mb
+import numpy as np
+import pytest
+from mbuild.tests.base_test import BaseTest
+from mbuild.utils.io import has_foyer
+
+
+class TestGSD(BaseTest):
+
+    def test_save(self, ethane):
+        ethane.save(filename='ethane.gsd')
+
+    @pytest.mark.skipif(not has_foyer, reason="Foyer is not installed")
+    def test_save_forcefield(self, ethane):
+        ethane.save(filename='ethane-opls.gsd',forcefield='opls')
+
+    @pytest.mark.skipif(not has_foyer, reason="Foyer is not installed")
+    def test_save_box(self, ethane):
+        box = mb.Box(lengths=np.array([2.0,2.0,2.0]))
+        ethane.save(filename='ethane-box.gsd',forcefield='opls',box=box)

--- a/mbuild/tests/test_gsd.py
+++ b/mbuild/tests/test_gsd.py
@@ -8,7 +8,7 @@ from mbuild.utils.io import has_foyer
 class TestGSD(BaseTest):
 
     def test_save(self, ethane):
-        ethane.save(filename='ethane.gsd')
+        ethane.save(filename='ethane.gsd',write_ff=False)
 
     @pytest.mark.skipif(not has_foyer, reason="Foyer is not installed")
     def test_save_forcefield(self, ethane):

--- a/mbuild/utils/io.py
+++ b/mbuild/utils/io.py
@@ -13,6 +13,12 @@ try:
 except ImportError:
     has_foyer = False
 
+try:
+    import gsd
+    has_gsd = True
+except ImportError:
+    has_gsd = False
+
 
 def get_fn(name):
     """Get the full path to one of the reference files shipped for utils.


### PR DESCRIPTION
A semi-limited GSD writer is now available for saving compounds in Hoomd's new data format.  As with the lammps and hoomdxml writers, the writer assumes certain functional forms for pair, bond, angle, and dihedral potentials (lj, harmonic, harmonic, opls, respectively).  As a result of the compound's conversion to a parmed structure, this limitation is not easily fixed.

Additionally, as the GSD format is not human-readable, a JSON file is optionally written which contains forcefield parameters to include in a Hoomd input script.