### PR TITLE
Automatically shifting port location to anchor location

### DIFF
--- a/mbuild/examples/pmpc/initiator.py
+++ b/mbuild/examples/pmpc/initiator.py
@@ -17,12 +17,12 @@ class Initiator(mb.Compound):
         # Add bottom port
         self.add(mb.Port(anchor=self[0]), 'down')
         # Place the port.
-        mb.translate(self['down'], self[0].pos + np.array([0.0, -0.07, 0.0]))
+        mb.translate(self['down'], np.array([0.0, -0.07, 0.0]))
 
         # Add top port.
         self.add(mb.Port(anchor=self[21]), 'up')
         # Place the port.
-        mb.translate(self['up'], self[21].pos + np.array([0.0, 0.07, 0.0]))
+        mb.translate(self['up'], np.array([0.0, 0.07, 0.0]))
 
 if __name__ == "__main__":
     ini = Initiator()

--- a/mbuild/examples/pmpc/mpc.py
+++ b/mbuild/examples/pmpc/mpc.py
@@ -21,12 +21,12 @@ class MPC(mb.Compound):
 
         # Add top port.
         self.add(mb.Port(anchor=C_top), label='up')
-        mb.translate(self['up'], C_top.pos - (C_top.pos - C_bottom.pos)*1.50)
+        mb.translate(self['up'], (C_bottom.pos - C_top.pos)*1.50)
 
         # Add bottom port
         self.add(mb.Port(anchor=C_bottom), 'down')
-        mb.rotate_around_y(self['down'], alpha)
-        mb.translate(self['down'], C_bottom.pos - (C_bottom.pos - C_top.pos)*1.50)
+        mb.spin_y(self['down'], alpha)
+        mb.translate(self['down'], (C_top.pos - C_bottom.pos)*1.50)
 
 if __name__ == "__main__":
     monomer = MPC()

--- a/mbuild/examples/tnp/sphere.py
+++ b/mbuild/examples/tnp/sphere.py
@@ -33,13 +33,13 @@ class Sphere(mb.Compound):
             self.add(port, "port_{}".format(i))
 
             # Make the top of the port point toward the positive x axis.
-            mb.rotate_around_z(port, -pi/2)
+            mb.spin_z(port, -pi/2)
             # Raise up (or down) the top of the port in the z direction.
-            mb.rotate_around_y(port, -arcsin(pos[2]/radius))
+            mb.spin_y(port, -arcsin(pos[2]/radius))
             # Rotate the Port along the z axis.
-            mb.rotate_around_z(port, arctan2(pos[1], pos[0]))
+            mb.spin_z(port, arctan2(pos[1], pos[0]))
             # Move the Port a bit away from the surface of the Sphere.
-            mb.translate(port, pos + (pos/radius * port_distance_from_surface))
+            mb.translate(port, pos/radius * port_distance_from_surface)
 
 if __name__ == "__main__":
     sphere = Sphere(n=4, radius=2)

--- a/mbuild/lib/atoms/c3.py
+++ b/mbuild/lib/atoms/c3.py
@@ -16,11 +16,11 @@ class C3(mb.Compound):
 
         self.add(mb.Port(anchor=self[0]), 'down')
         mb.translate(self['down'], np.array([0, 0.07, 0]))
-        mb.rotate_around_z(self['down'], np.pi * 2/3)
+        mb.spin_z(self['down'], np.pi * 2/3)
 
         self.add(mb.Port(anchor=self[0]), 'left')
         mb.translate(self['left'], np.array([0, 0.07, 0]))
-        mb.rotate_around_z(self['left'], -np.pi * 2/3)
+        mb.spin_z(self['left'], -np.pi * 2/3)
 
 
 if __name__ == '__main__':

--- a/mbuild/lib/atoms/h.py
+++ b/mbuild/lib/atoms/h.py
@@ -10,7 +10,7 @@ class H(mb.Compound):
         self.add(mb.Particle(name='H'))
 
         self.add(mb.Port(anchor=self[0]), 'up')
-        mb.rotate_around_z(self['up'], np.pi)
+        mb.spin_z(self['up'], np.pi)
         mb.translate(self['up'], np.array([0, 0.07, 0]))
 
 if __name__ == '__main__':

--- a/mbuild/lib/moieties/ester.py
+++ b/mbuild/lib/moieties/ester.py
@@ -12,11 +12,11 @@ class Ester(mb.Compound):
         mb.translate(self, -self[0].pos)
 
         self.add(mb.Port(anchor=self[2]), 'up')
-        mb.rotate_around_z(self['up'], np.pi / 2)
-        mb.translate_to(self['up'], self[2].pos + np.array([0.07, 0, 0]))
+        mb.spin_z(self['up'], np.pi / 2)
+        mb.translate_to(self['up'], np.array([0.07, 0, 0]))
 
         self.add(mb.Port(anchor=self[0]), 'down')
-        mb.rotate_around_z(self['down'], np.pi / 2)
+        mb.spin_z(self['down'], np.pi / 2)
         mb.translate(self['down'], np.array([-0.07, 0, 0]))
 
 if __name__ == '__main__':

--- a/mbuild/lib/surfaces/amorphous_silica.py
+++ b/mbuild/lib/surfaces/amorphous_silica.py
@@ -23,8 +23,8 @@ class AmorphousSilica(mb.Compound):
             if particle.name == 'OB':
                 count += 1
                 port = mb.Port(anchor=particle)
-                mb.rotate_around_x(port, np.pi/2)
-                mb.translate(port, particle.pos + np.array([0, 0, .1]))
+                mb.spin_x(port, np.pi/2)
+                mb.translate(port, np.array([0, 0, .1]))
                 self.add(port, 'port_{}'.format(count))
 
 if __name__ == "__main__":

--- a/mbuild/lib/surfaces/betacristobalite.py
+++ b/mbuild/lib/surfaces/betacristobalite.py
@@ -32,8 +32,8 @@ class Betacristobalite(mb.Compound):
             if particle.name.startswith('O') and particle.pos[2] > 1.0:
                 count += 1
                 port = mb.Port(anchor=particle)
-                mb.rotate_around_x(port, np.pi/2)
-                mb.translate(port, particle.pos + np.array([0, 0, .1]))
+                mb.spin_x(port, np.pi/2)
+                mb.translate(port, np.array([0, 0, .1]))
                 self.add(port, 'port_{}'.format(count))
                 particle.name = 'O'  # Strip numbers required in .mol2 files.
             elif particle.name.startswith('Si'):

--- a/mbuild/pattern.py
+++ b/mbuild/pattern.py
@@ -188,11 +188,11 @@ class SpherePattern(Pattern):
             port = Port()
             ports.append(port)
             # Make the top of the port point toward the positive x axis.
-            rotate_around_z(port, -np.pi/2)
+            spin_z(port, -np.pi/2)
             # Raise up (or down) the top of the port in the z direction.
-            rotate_around_y(port, -np.arcsin(point[2]))
+            spin_y(port, -np.arcsin(point[2]))
             # Rotate the Port along the z axis.
-            rotate_around_z(port, np.arctan2(point[1], point[0]))
+            spin_z(port, np.arctan2(point[1], point[0]))
             # Move the Port a bit away from the surface of the Sphere.
             #translate(port, point + 0.07)
 

--- a/mbuild/pattern.py
+++ b/mbuild/pattern.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from mbuild.coordinate_transform import (equivalence_transform, translate,
                                          rotate_around_x, rotate_around_y,
-                                         rotate_around_z)
+                                         rotate_around_z, spin_y, spin_z)
 from mbuild.utils.validation import assert_port_exists
 from mbuild import clone
 

--- a/mbuild/port.py
+++ b/mbuild/port.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from mbuild.compound import Compound, Particle
-from mbuild.coordinate_transform import rotate_around_z
+from mbuild.coordinate_transform import spin_z
 from mbuild import clone
 
 

--- a/mbuild/port.py
+++ b/mbuild/port.py
@@ -31,16 +31,20 @@ class Port(Compound):
     def __init__(self, anchor=None):
         super(Port, self).__init__(name='Port', port_particle=True)
         self.anchor = anchor
+        if anchor:
+            shift = anchor.xyz
+        else:
+            shift = np.zeros(3)
 
         up = Compound(name='subport', port_particle=True)
-        up.add(Particle(name='G', pos=[0, 0, 0], port_particle=True), 'middle')
-        up.add(Particle(name='G', pos=[0, 0.02, 0], port_particle=True), 'top')
-        up.add(Particle(name='G', pos=[-0.02, -0.01, 0], port_particle=True), 'left')
-        up.add(Particle(name='G', pos=[0.0, -0.02, 0.01], port_particle=True), 'right')
+        up.add(Particle(name='G', pos=[0, 0, 0] + shift, port_particle=True), 'middle')
+        up.add(Particle(name='G', pos=[0, 0.02, 0] + shift, port_particle=True), 'top')
+        up.add(Particle(name='G', pos=[-0.02, -0.01, 0] + shift, port_particle=True), 'left')
+        up.add(Particle(name='G', pos=[0.0, -0.02, 0.01] + shift, port_particle=True), 'right')
 
         down = clone(up)
 
-        rotate_around_z(down, np.pi)
+        spin_z(down, np.pi)
 
         self.add(up, 'up')
         self.add(down, 'down')

--- a/mbuild/port.py
+++ b/mbuild/port.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from mbuild.compound import Compound, Particle
-from mbuild.coordinate_transform import spin_z
+from mbuild.coordinate_transform import rotate_around_z, translate_to
 from mbuild import clone
 
 
@@ -31,24 +31,22 @@ class Port(Compound):
     def __init__(self, anchor=None):
         super(Port, self).__init__(name='Port', port_particle=True)
         self.anchor = anchor
-        if anchor:
-            shift = anchor.xyz
-        else:
-            shift = np.zeros(3)
 
         up = Compound(name='subport', port_particle=True)
-        up.add(Particle(name='G', pos=[0, 0, 0] + shift, port_particle=True), 'middle')
-        up.add(Particle(name='G', pos=[0, 0.02, 0] + shift, port_particle=True), 'top')
-        up.add(Particle(name='G', pos=[-0.02, -0.01, 0] + shift, port_particle=True), 'left')
-        up.add(Particle(name='G', pos=[0.0, -0.02, 0.01] + shift, port_particle=True), 'right')
+        up.add(Particle(name='G', pos=[0, 0, 0], port_particle=True), 'middle')
+        up.add(Particle(name='G', pos=[0, 0.02, 0], port_particle=True), 'top')
+        up.add(Particle(name='G', pos=[-0.02, -0.01, 0], port_particle=True), 'left')
+        up.add(Particle(name='G', pos=[0.0, -0.02, 0.01], port_particle=True), 'right')
 
         down = clone(up)
-
-        spin_z(down, np.pi)
+        rotate_around_z(down, np.pi)
 
         self.add(up, 'up')
         self.add(down, 'down')
         self.used = False
+
+        if anchor:
+            translate_to(self, anchor.xyz[0])
 
     def _clone(self, clone_of=None, root_container=None):
         newone = super(Port, self)._clone(clone_of, root_container)

--- a/mbuild/port.py
+++ b/mbuild/port.py
@@ -46,7 +46,7 @@ class Port(Compound):
         self.used = False
 
         if anchor:
-            translate_to(self, anchor.xyz[0])
+            translate_to(self, anchor.pos)
 
     def _clone(self, clone_of=None, root_container=None):
         newone = super(Port, self)._clone(clone_of, root_container)

--- a/mbuild/recipes/silica_interface.py
+++ b/mbuild/recipes/silica_interface.py
@@ -130,8 +130,8 @@ class SilicaInterface(mb.Compound):
                 if atom.name == 'O' and atom.pos[2] > thickness:
                     atom.name = 'OS'
                     port = mb.Port(anchor=atom)
-                    mb.rotate_around_x(port, np.pi/2)
-                    mb.translate(port, atom.pos + np.array([0.0, 0.0, 0.1]))
+                    mb.spin_x(port, np.pi/2)
+                    mb.translate(port, np.array([0.0, 0.0, 0.1]))
                     self.add(port, "port_{}".format(len(self.referenced_ports())))
 
     def _adjust_stoichiometry(self):

--- a/mbuild/tests/test_port.py
+++ b/mbuild/tests/test_port.py
@@ -1,0 +1,16 @@
+import pytest
+import numpy as np
+import mbuild as mb
+from mbuild.tests.base_test import BaseTest
+
+
+class TestPattern(BaseTest):
+
+    def test_port_center(self):
+        port = mb.Port()
+        assert [round(coord,3)==0 for coord in port.center]
+
+    def test_port_shift(self, ethane):
+        mb.translate_to(ethane, np.ones(3))
+        port = mb.Port(anchor=ethane)
+        assert [ethane.center[i]==coord for i,coord in enumerate(port.center)]


### PR DESCRIPTION
Rather than ports being located at the origin upon creation, they are now shifted to the location of the anchor particle if one is provided.  This approach seems a bit more intuitive.  This also means that previous scripts where port locations are shifted manually will now be broken.  I've removed the manual shifting of ports created with recipes, library compounds, and the examples.  I've also changed port rotations from "rotate_about_..." to "spin_..." since ports are no longer always located at the origin.